### PR TITLE
fix: update fxmanifest version to match latest release

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,7 +4,7 @@ lua54 "yes"
 
 author "JG Scripts"
 description "Tracks vehicle mileage with UI"
-version "v1.2"
+version "2.0"
 
 shared_scripts {
   "@ox_lib/init.lua",


### PR DESCRIPTION
the version number in `fxmanifest.lua` was not updated to reflect the latest release