### PR TITLE
fix(client.lua): prevent script error when vehicle plate is nil

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -16,7 +16,12 @@ local function sendToNui(data)
 end
 
 local function getVehiclePlate(vehicle)
-  return string.gsub(GetVehicleNumberPlateText(vehicle), "^%s*(.-)%s*$", "%1")
+    if not vehicle or not DoesEntityExist(vehicle) then return nil end
+
+    local plate = GetVehicleNumberPlateText(vehicle)
+    if not plate then return nil end
+
+    return string.gsub(plate, "^%s*(.-)%s*$", "%1")
 end
 
 local function distanceCheck()


### PR DESCRIPTION
- added checks to ensure `GetVehicleNumberPlateText` doesn't return nil before using `gsub`

fixes this:
![image](https://github.com/user-attachments/assets/46bd14ad-cc15-45de-993a-4c8809ce0503)
