### PR TITLE
Add script compatibility and mileage update

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,7 +1,20 @@
 Config = {}
+
 Config.AutoRunSQL = true
 
-Config.Framework = "auto" -- or "QBCore", "Qbox", "ESX"
+---@type "auto" | "QBCore" | "Qbox" | "ESX"
+Config.Framework = "auto"
+
+-- This setting will not work if you are using jg-hud or tgiann-lumihud.
 Config.ShowMileage = true
-Config.Unit = "miles" -- "miles" or "kilometers"
-Config.Position = "bottom-right" -- "bottom-right" or "bottom-left" or "top-right" or "top-left" or "bottom-center" or "top-center"
+
+---@type "miles" | "kilometers"
+Config.Unit = "miles"
+
+---@type "bottom-right" | "bottom-left" | "top-right" | "top-left" | "bottom-center" | "top-center"
+Config.Position = "bottom-right"
+
+Config.ScriptCompatibility = {
+    ["tgiann-lumihud"] = false, -- If you set this to true, you must also set the config.customMileageSystem setting to true in the tgiann-lumihud script.
+    ["jg-hud"] = GetResourceState("jg-hud") == "started"
+}

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,7 +4,7 @@ lua54 "yes"
 
 author "JG Scripts"
 description "Tracks vehicle mileage with UI"
-version "v2.1.1"
+version "v2.2.0"
 
 shared_scripts {
   "@ox_lib/init.lua",
@@ -21,6 +21,6 @@ server_scripts {
 
 ui_page "web/index.html"
 
-files {"web/*"}
+files { "web/*" }
 
-escrow_ignore {"**/*"}
+escrow_ignore { "**/*" }


### PR DESCRIPTION
Refactor client logic to support external HUDs and centralize mileage updates. Introduces canShowMenu() and updateVehicleMileage() to handle visibility and mileage state/exporting (including tgiann-lumihud integration) and reduces duplicated TriggerServerEvent/Entity.state code. Config gains typed annotations, a ScriptCompatibility table (auto-detects jg-hud and toggles tgiann-lumihud compatibility), and guidance about ShowMileage interaction. Bump fxmanifest version to v2.2.0 and apply minor formatting changes.